### PR TITLE
Add "Change All End Of Line Sequence" extension to devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,8 @@
                 "Azurite.azurite",
                 "ms-azuretools.vscode-azurestorage",
                 "ms-azuretools.vscode-bicep",
-                "ms-vscode.azure-account"
+                "ms-vscode.azure-account",
+                "vs-publisher-1448185.keyoti-changeallendoflinesequence"
             ],
             "settings": {
                 "workbench.colorTheme": "Copilot Theme"	


### PR DESCRIPTION
This pull request makes a small update to the development container configuration by adding a new recommended VS Code extension.

It allow to change CRLF to LF and the other way round by executing "Change End of Line Sequence" in the VS Code menu

<img width="1152" height="123" alt="image" src="https://github.com/user-attachments/assets/084ad64a-4cf9-4641-9b99-df3af1b513a2" />
 